### PR TITLE
Make HOME writable. Fixes #2

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -2,7 +2,7 @@ FROM alpine/helm:VERSION
 ARG AWS_REGION
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
-
+ENV HOME /tmp
 RUN helm init -c && \
     apk add --update --no-cache git bash && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,16 @@
-
-
-VERSION=$(shell cat VERSION)
+HELM_VERSION	= $(shell cat VERSION)
+IMAGE_VERSION	= $(HELM_VERSION)-$(shell git describe --always --tags)
 
 default: Dockerfile
-	docker build -t infobloxcto/helm:$(VERSION) \
+	docker build -t infobloxcto/helm:$(IMAGE_VERSION) \
 		--build-arg AWS_REGION=$(AWS_REGION) \
 		--build-arg AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
 		--build-arg AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
 		.
-	docker push infobloxcto/helm:$(VERSION)
+	docker push infobloxcto/helm:$(IMAGE_VERSION)
 
 Dockerfile: Dockerfile.in VERSION
-	sed "s/VERSION/$(VERSION)/g" Dockerfile.in > .Dockerfile
+	sed "s/VERSION/$(HELM_VERSION)/g" Dockerfile.in > .Dockerfile
 	mv .Dockerfile Dockerfile
 
 clean:


### PR DESCRIPTION
Demo:
```
$ docker run --rm -it --user 1000:1000 helm:2.14.3 init -c
$HELM_HOME has been configured at /tmp/.helm.
Not installing Tiller due to 'client-only' flag having been set
```