### PR TITLE
build-args leak credentials

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,13 @@
 FROM alpine/helm:VERSION
 ENV HOME /tmp
+ADD entrypoint.sh /entrypoint.sh
+
+#FIXME: add versioning to helm-s3
+
 RUN helm init -c && \
     apk add --update --no-cache git bash && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
-    rm -f /var/cache/apk/*
+    rm -f /var/cache/apk/* && \
+    ln -s /usr/bin/helm /usr/bin/helmnoaws
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,10 +1,6 @@
 FROM alpine/helm:VERSION
-ARG AWS_REGION
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
 ENV HOME /tmp
 RUN helm init -c && \
     apk add --update --no-cache git bash && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     rm -f /var/cache/apk/*
-RUN helm repo add infobloxcto s3://infoblox-helm-dev/charts

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,7 @@ HELM_VERSION	= $(shell cat VERSION)
 IMAGE_VERSION	= $(HELM_VERSION)-$(shell git describe --always --tags)
 
 default: Dockerfile
-	docker build -t infobloxcto/helm:$(IMAGE_VERSION) \
-		--build-arg AWS_REGION=$(AWS_REGION) \
-		--build-arg AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
-		--build-arg AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
-		.
+	docker build -t infobloxcto/helm:$(IMAGE_VERSION) .
 	docker push infobloxcto/helm:$(IMAGE_VERSION)
 
 Dockerfile: Dockerfile.in VERSION
@@ -15,4 +11,3 @@ Dockerfile: Dockerfile.in VERSION
 
 clean:
 	rm -f Dockerfile .Dockerfile
-

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ HELM_VERSION	= $(shell cat VERSION)
 IMAGE_VERSION	= $(HELM_VERSION)-$(shell git describe --always --tags)
 
 default: Dockerfile
-	docker build -t infobloxcto/helm:$(IMAGE_VERSION) .
-	docker push infobloxcto/helm:$(IMAGE_VERSION)
+	docker build -t infoblox/helm:$(IMAGE_VERSION) .
+	docker push infoblox/helm:$(IMAGE_VERSION)
 
 Dockerfile: Dockerfile.in VERSION
 	sed "s/VERSION/$(HELM_VERSION)/g" Dockerfile.in > .Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# helm requested, sync the infoblox s3 bucket
+if [ -z "$NOAWS" ] && [ "$1" = 'helm' ] && [ "$2" != 'version' ] && [ "$2" != 'lint' ] && [ "$2" != 'template' ];
+then
+
+    if ! helm repo list | grep 'infobloxcto[[:space:]]\+s3://infoblox-helm-dev/charts' > /dev/null
+    then
+        helm repo add infobloxcto s3://infoblox-helm-dev/charts >&2
+    fi
+    helm repo update >&2
+fi
+
+exec "$@"


### PR DESCRIPTION
DEMO

```
-> % AWS_REGION=$(aws configure get region) AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) docker run -it -e AWS_REGION -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID infoblox/helm:2.14.3-ab8a8b3 helm search authz
"infobloxcto" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "infobloxcto" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete.
NAME                            CHART VERSION           APP VERSION     DESCRIPTION
REDACTED               REDACTED       v2.0.0          A Helm chart for Authz
```

```
-> % docker run -it -e NOAWS=1  infoblox/helm:2.14.3-ab8a8b3 helm search authz
No results found
```