### PR TITLE
Fix errors related to removal of kubernetes-charts.storage.googleapis.com

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -3,7 +3,7 @@ ENV HOME /tmp
 
 #FIXME: add versioning to helm-s3
 
-RUN helm init -c && \
+RUN helm init -c --stable-repo-url https://charts.helm.sh/stable/ && \
     apk add --update --no-cache git bash && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     rm -f /var/cache/apk/* && \


### PR DESCRIPTION
Fixes errors like this:

    Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com  
    Error: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: 
    Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden