### PR TITLE
avoid s3 sync on more commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 # helm requested, sync the infoblox s3 bucket
-if [ -z "$NOAWS" ] && [ "$1" = 'helm' ] && [ "$2" != 'version' ] && [ "$2" != 'lint' ] && [ "$2" != 'template' ];
+if [ -z "$NOAWS" ] && [ "$1" = 'helm' ] && [ "$2" != 'version' ] && [ "$2" != 'lint' ] && [ "$2" != 'template' ] && [ "$2" != 'package' ] && [ "$2" != 'dependency' ] && [ "$2" != 'dep' ];
 then
 
     if ! helm repo list | grep 'infobloxcto[[:space:]]\+s3://infoblox-helm-dev/charts' > /dev/null


### PR DESCRIPTION
DEMO
After
```
-> % DRY_RUN=1 make crossplane
makefile:47: warning: overriding recipe for target 'upstream'                                                                                                                                              makefile:39: warning: ignoring old recipe for target 'upstream'
docker run --rm -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v /home/drew/src/github.com/Infoblox-CTO/charts:/pkg -w /pkg infoblox/helm:3.9.4-780cef5 lint crossplane
==> Linting crossplane
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
docker run --rm -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v /home/drew/src/github.com/Infoblox-CTO/charts:/pkg -w /pkg infoblox/helm:3.9.4-780cef5 package crosspla
ne --version 0.1.1-j0 --app-version 0.1.1-j0
Successfully packaged chart and saved it to: /pkg/crossplane-0.1.1-j0.tgz
```

Before
```
-> % DRY_RUN=1 make crossplane
makefile:47: warning: overriding recipe for target 'upstream'
makefile:39: warning: ignoring old recipe for target 'upstream'
docker run --rm -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v /home/drew/src/github.com/Infoblox-CTO/charts:/pkg -w /pkg infoblox/helm:3.9.4-3e054b7 lint crossplane
==> Linting crossplane
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
docker run --rm -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v .../Infoblox-CTO/charts:/pkg -w /pkg infoblox/helm:3.9.4-3e05a package crossplane --version 0.1.1-j0 --app-version 0.1.1-j0
Error: no repositories to show
Error: fetch from s3 url=s3://.../charts/index.yaml: fetch object from s3: ExpiredToken: The provided token has expired.
        status code: 400, request id: ..., host id: 1...
Error: looks like "s3://.../charts" is not a valid chart repository or cannot be reached: plugin "bin/helm-s3 download" exited with error
make: *** [makefile:40: crossplane] Error 1
```

