### PR TITLE
allow unknown users to modify helm cache files

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -14,6 +14,8 @@ RUN apk add --update --no-cache git bash && \
 # Fake a repo when entrypoint is overridden
 ADD repositories.yaml $HELM_HOME/repository/repositories.yaml
 ADD cache.yaml $HELM_HOME/repository/cache/infobloxcto-index.yaml
+RUN chmod a+rw $HELM_HOME/repository/repositories.yaml $HELM_HOME/repository/cache/infobloxcto-index.yaml
+RUN chmod a+rwx $HELM_HOME/repository/ $HELM_HOME/repository/cache/
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Fixes permission issues when passing in a user from system

```
❯ docker run -it -u $(id -g):$(id -u) --entrypoint '' docker.io/infoblox/helm:3.9.4-8844c30 rm /repository/repositories.yaml
❯ echo $?
0
```

```
docker run --rm -u $(id -g):$(id -u) -v /home/drew/src
/github.com/Infoblox-CTO/charts:/pkg -w /pkg infoblox/helm:3.9.4-8844c30 lint crossplane-provider-persona
==> Linting crossplane-provider-persona
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```
